### PR TITLE
Can edit URI

### DIFF
--- a/packages/hardhat/contracts/FancyBee.sol
+++ b/packages/hardhat/contracts/FancyBee.sol
@@ -12,6 +12,7 @@ import "@openzeppelin/contracts/utils/Counters.sol";
 contract FancyBee is ERC721 {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
+
     uint totalBeeSupply = 5;
 
     constructor(string memory tokenName, string memory symbol) ERC721(tokenName, symbol) {
@@ -32,5 +33,10 @@ contract FancyBee is ERC721 {
         _setTokenURI(id, metadataURI);
 
         return id;
+    }
+    
+    function setTokenURI(uint256 _tokenId, string memory _tokenURI) external returns (string memory) {
+        _setTokenURI(_tokenId, _tokenURI);
+        return tokenURI(_tokenId);
     }
 }


### PR DESCRIPTION
Added functionality for a contract that imports this contract into their contract to set URI. I don't know what the contract of the DAO would be, but when I do, I could hardcode that in. It would look something like 
`uint256 DAO_Address = fbnjhdksalbfhjkdsa; 
function ... {
require(DAO_address == msg.sender, "Operation only available to DAO");`